### PR TITLE
#15 Unicode 14 update

### DIFF
--- a/USE/IndicPositionalCategory-Additional.txt
+++ b/USE/IndicPositionalCategory-Additional.txt
@@ -6,7 +6,7 @@
 # Updated for L2/19-083    by Andrew Glass 2019-05-06
 # Updated for Unicode 12.1 by Andrew Glass 2019-05-30
 # Updated for Unicode 13.0 by Andrew Glass 2020-07-28
-# Updated for Unicode 14.0 by Andrew Glass 2021-09-25
+# Updated for Unicode 14.0 by Andrew Glass 2021-09-28
 
 # ================================================
 # ================================================
@@ -58,14 +58,16 @@ AA35          ; Top     # Mn       CHAM CONSONANT SIGN
 # Indic_Positional_Category=Bottom
 0859..085B    ; Bottom # Mn   [3] MANDAIC AFFRICATION MARK..MANDAIC GEMINATION MARK
 18A9          ; Bottom # Mn       MONGOLIAN LETTER ALI GALI DAGALGA
-10AE5         ; Bottom # Mn       MANICHAEAN ABBREVIATION MARK ABOVE # Not really bottom, but here for ccc to control
+10AE5         ; Bottom # Mn       MANICHAEAN ABBREVIATION MARK ABOVE  # Overriden, ccc controls order
 10AE6         ; Bottom # Mn       MANICHAEAN ABBREVIATION MARK BELOW
 10F46..10F47  ; Bottom # Mn   [2] SOGDIAN COMBINING DOT BELOW..SOGDIAN COMBINING TWO DOTS BELOW
-10F48..10F4A  ; Bottom # Mn   [3] SOGDIAN COMBINING DOT ABOVE..SOGDIAN COMBINING CURVE ABOVE # Overriden to below because ccc-based Normalization controls order
+10F48..10F4A  ; Bottom # Mn   [3] SOGDIAN COMBINING DOT ABOVE..SOGDIAN COMBINING CURVE ABOVE     # Overriden, ccc controls order
 10F4B         ; Bottom # Mn       SOGDIAN COMBINING CURVE BELOW
-10F4C         ; Bottom # Mn       SOGDIAN COMBINING HOOK ABOVE # Overriden to below because ccc-based Normalization controls order
+10F4C         ; Bottom # Mn       SOGDIAN COMBINING HOOK ABOVE        # Overriden, ccc controls order
 10F4D..10F50  ; Bottom # Mn   [4] SOGDIAN COMBINING HOOK BELOW..SOGDIAN COMBINING STROKE BELOW
+10F82         ; Bottom # Mn       OLD UYGHUR COMBINING DOT ABOVE      # Overriden, ccc controls order
 10F83         ; Bottom # Mn       OLD UYGHUR COMBINING DOT BELOW
+10F84         ; Bottom # Mn       OLD UYGHUR COMBINING TWO DOTS ABOVE # Overriden, ccc controls order
 10F85         ; Bottom # Mn       OLD UYGHUR COMBINING TWO DOTS BELOW
 16F4F         ; Bottom # Mn       MIAO SIGN CONSONANT MODIFIER BAR
 16F51..16F87  ; Bottom # Mc  [55] MIAO SIGN ASPIRATION..MIAO VOWEL SIGN UI
@@ -84,8 +86,6 @@ AA35          ; Top     # Mn       CHAM CONSONANT SIGN
 1885..1886    ; Top   # Mn   [2] MONGOLIAN LETTER ALI GALI BALUDA..MONGOLIAN LETTER ALI GALI THREE BALUDA
 10D24..10D27  ; Top   # Mn   [4] HANIFI ROHINGYA SIGN HARBAHAY..HANIFI ROHINGYA SIGN TASSI
 10EAB..10EAC  ; Top   # Mn   [2] YEZIDI COMBINING HAMZA MARK..YEZIDI COMBINING MADDA MARK
-10F82         ; Top   # Mn       OLD UYGHUR COMBINING DOT ABOVE
-10F84         ; Top   # Mn       OLD UYGHUR COMBINING TWO DOTS ABOVE
 16B30..16B36  ; Top   # Mn   [7] PAHAWH HMONG MARK CIM TUB..PAHAWH HMONG MARK CIM TAUM
 1E130..1E136  ; Top   # Mn   [7] NYIAKENG PUACHUE HMONG TONE-B..NYIAKENG PUACHUE HMONG TONE-D
 1E2AE         ; Top   # Mn       TOTO SIGN RISING TONE

--- a/USE/IndicPositionalCategory-Additional.txt
+++ b/USE/IndicPositionalCategory-Additional.txt
@@ -1,11 +1,12 @@
 # Override values For Indic_Positional_Category
 # Not derivable
 # Initial version based on Unicode 7.0 by Andrew Glass 2014-03-17
-# Updated  for Unicode 10.0 by Andrew Glass 2017-07-25
+# Updated for Unicode 10.0 by Andrew Glass 2017-07-25
 # Ammended for Unicode 10.0 by Andrew Glass 2018-09-21
-# Updated  for L2/19-083    by Andrew Glass 2019-05-06
-# Updated  for Unicode 12.1 by Andrew Glass 2019-05-30
-# Updated  for Unicode 13.0 by Andrew Glass 2020-07-28
+# Updated for L2/19-083    by Andrew Glass 2019-05-06
+# Updated for Unicode 12.1 by Andrew Glass 2019-05-30
+# Updated for Unicode 13.0 by Andrew Glass 2020-07-28
+# Updated for Unicode 14.0 by Andrew Glass 2021-09-25
 
 # ================================================
 # ================================================
@@ -14,39 +15,39 @@
 # ================================================
 
 # Indic_Positional_Category=Bottom
-0F72        ; Bottom  # Mn      TIBETAN VOWEL SIGN I # Not really below, but need to override to fit into Universal model
-0F7A..0F7D  ; Bottom  # Mn  [4] TIBETAN VOWEL SIGN E..TIBETAN VOWEL SIGN OO # Not really below, but need to override to fit into Universal model
-0F80        ; Bottom  # Mn      TIBETAN VOWEL SIGN REVERSED I # Not really below, but need to override to fit into Universal model
-A9BF        ; Bottom  # Mc      JAVANESE CONSONANT SIGN CAKRA
-11127..11129; Bottom  # Mn  [3] CHAKMA VOWEL SIGN A..CHAKMA VOWEL SIGN II
-1112D       ; Bottom  # Mn      CHAKMA VOWEL SIGN AI
-11130       ; Bottom  # Mn      CHAKMA VOWEL SIGN OI
+0F72          ; Bottom  # Mn      TIBETAN VOWEL SIGN I # Not really below, but need to override to fit into Universal model
+0F7A..0F7D    ; Bottom  # Mn  [4] TIBETAN VOWEL SIGN E..TIBETAN VOWEL SIGN OO # Not really below, but need to override to fit into Universal model
+0F80          ; Bottom  # Mn      TIBETAN VOWEL SIGN REVERSED I # Not really below, but need to override to fit into Universal model
+A9BF          ; Bottom  # Mc      JAVANESE CONSONANT SIGN CAKRA
+11127..11129  ; Bottom  # Mn  [3] CHAKMA VOWEL SIGN A..CHAKMA VOWEL SIGN II
+1112D         ; Bottom  # Mn      CHAKMA VOWEL SIGN AI
+11130         ; Bottom  # Mn      CHAKMA VOWEL SIGN OI
 
 # ================================================
 
 # Indic_Positional_Category=Left
-1C29        ; Left    # Mc      LEPCHA VOWEL SIGN OO  # Reduced from Top_And_Left
+1C29          ; Left    # Mc      LEPCHA VOWEL SIGN OO  # Reduced from Top_And_Left
 
 # ================================================
 
 
 # Indic_Positional_Category=Right
-A9BE        ; Right   # Mc      JAVANESE CONSONANT SIGN PENGKAL # Reduced from Bottom_And_Right
-10A0C       ; Right   # Mn      KHAROSHTHI VOWEL LENGTH MARK    # Follows vowels and precedes vowel modifiers
-11942       ; Right   # Mc      DIVES AKURU MEDIAL RA           # Reduced from Bottom_And_Right
+A9BE          ; Right   # Mc      JAVANESE CONSONANT SIGN PENGKAL # Reduced from Bottom_And_Right
+10A0C         ; Right   # Mn      KHAROSHTHI VOWEL LENGTH MARK    # Follows vowels and precedes vowel modifiers
+11942         ; Right   # Mc      DIVES AKURU MEDIAL RA           # Reduced from Bottom_And_Right
 
 # ================================================
 
 # Indic_Positional_Category=Top
-0F74         ; Top   # Mn       TIBETAN VOWEL SIGN U # Not really above, but need to override to fit into Universal model
-1A18         ; Top   # Mn       BUGINESE VOWEL SIGN U # Workaround to allow below to occur before above by treating all below marks as above
-AA35         ; Top   # Mn       CHAM CONSONANT SIGN
+0F74          ; Top     # Mn       TIBETAN VOWEL SIGN U # Not really above, but need to override to fit into Universal model
+1A18          ; Top     # Mn       BUGINESE VOWEL SIGN U # Workaround to allow below to occur before above by treating all below marks as above
+AA35          ; Top     # Mn       CHAM CONSONANT SIGN
 
 # ================================================
 
 # Indic_Positional_Category=Top_And_Right
-0E33    ; Top_And_Right # Lo       THAI CHARACTER SARA AM # IMC has Right, which seems to be a mistake.
-0EB3    ; Top_And_Right # Lo       LAO VOWEL SIGN AM # IMC has Right, which seems to be a mistake.
+0E33          ; Top_And_Right # Lo       THAI CHARACTER SARA AM # IMC has Right, which seems to be a mistake.
+0EB3          ; Top_And_Right # Lo       LAO VOWEL SIGN AM # IMC has Right, which seems to be a mistake.
 
 # ================================================
 # ================================================
@@ -55,41 +56,46 @@ AA35         ; Top   # Mn       CHAM CONSONANT SIGN
 # ================================================
 
 # Indic_Positional_Category=Bottom
-0859..085B   ; Bottom # Mn   [3] MANDAIC AFFRICATION MARK..MANDAIC GEMINATION MARK
-18A9         ; Bottom # Mn       MONGOLIAN LETTER ALI GALI DAGALGA
-10AE5        ; Bottom # Mn       MANICHAEAN ABBREVIATION MARK ABOVE # Not really bottom, but here for ccc to control
-10AE6        ; Bottom # Mn       MANICHAEAN ABBREVIATION MARK BELOW
-10F46..10F47 ; Bottom # Mn   [2] SOGDIAN COMBINING DOT BELOW..SOGDIAN COMBINING TWO DOTS BELOW
-10F48..10F4A ; Bottom # Mn   [3] SOGDIAN COMBINING DOT ABOVE..SOGDIAN COMBINING CURVE ABOVE # Overriden to below because ccc-based Normalization controls order
-10F4B        ; Bottom # Mn       SOGDIAN COMBINING CURVE BELOW
-10F4C        ; Bottom # Mn       SOGDIAN COMBINING HOOK ABOVE # Overriden to below because ccc-based Normalization controls order
-10F4D..10F50 ; Bottom # Mn   [4] SOGDIAN COMBINING HOOK BELOW..SOGDIAN COMBINING STROKE BELOW
-16F4F        ; Bottom # Mn       MIAO SIGN CONSONANT MODIFIER BAR
-16F51..16F87 ; Bottom # Mc  [55] MIAO SIGN ASPIRATION..MIAO VOWEL SIGN UI
-16F8F..16F92 ; Bottom # Mn   [4] MIAO TONE RIGHT..MIAO TONE BELOW
+0859..085B    ; Bottom # Mn   [3] MANDAIC AFFRICATION MARK..MANDAIC GEMINATION MARK
+18A9          ; Bottom # Mn       MONGOLIAN LETTER ALI GALI DAGALGA
+10AE5         ; Bottom # Mn       MANICHAEAN ABBREVIATION MARK ABOVE # Not really bottom, but here for ccc to control
+10AE6         ; Bottom # Mn       MANICHAEAN ABBREVIATION MARK BELOW
+10F46..10F47  ; Bottom # Mn   [2] SOGDIAN COMBINING DOT BELOW..SOGDIAN COMBINING TWO DOTS BELOW
+10F48..10F4A  ; Bottom # Mn   [3] SOGDIAN COMBINING DOT ABOVE..SOGDIAN COMBINING CURVE ABOVE # Overriden to below because ccc-based Normalization controls order
+10F4B         ; Bottom # Mn       SOGDIAN COMBINING CURVE BELOW
+10F4C         ; Bottom # Mn       SOGDIAN COMBINING HOOK ABOVE # Overriden to below because ccc-based Normalization controls order
+10F4D..10F50  ; Bottom # Mn   [4] SOGDIAN COMBINING HOOK BELOW..SOGDIAN COMBINING STROKE BELOW
+10F83         ; Bottom # Mn       OLD UYGHUR COMBINING DOT BELOW
+10F85         ; Bottom # Mn       OLD UYGHUR COMBINING TWO DOTS BELOW
+16F4F         ; Bottom # Mn       MIAO SIGN CONSONANT MODIFIER BAR
+16F51..16F87  ; Bottom # Mc  [55] MIAO SIGN ASPIRATION..MIAO VOWEL SIGN UI
+16F8F..16F92  ; Bottom # Mn   [4] MIAO TONE RIGHT..MIAO TONE BELOW
 
 # ================================================
 
 # Indic_Positional_Category=Left
-103C          ; Left # Mc       MYANMAR CONSONANT SIGN MEDIAL RA
+103C          ; Left   # Mc       MYANMAR CONSONANT SIGN MEDIAL RA
 
 # ================================================
 
 # Indic_Positional_Category=Top
-07EB..07F3   ; Top   # Mn   [9] NKO COMBINING SHORT HIGH TONE..NKO COMBINING DOUBLE DOT ABOVE
-07FD         ; Top   # Mn       NKO DANTAYALAN # Not really top, but assigned here to allow ccc to control mark order
-1885..1886   ; Top   # Mn   [2] MONGOLIAN LETTER ALI GALI BALUDA..MONGOLIAN LETTER ALI GALI THREE BALUDA
-10EAB..10EAC ; Top   # Mn   [2] YEZIDI COMBINING HAMZA MARK..YEZIDI COMBINING MADDA MARK
-1E944..1E94A ; Top   # Mn   [7] ADLAM ALIF LENGTHENER..ADLAM NUKTA
-10D24..10D27 ; Top   # Mn   [4] HANIFI ROHINGYA SIGN HARBAHAY..HANIFI ROHINGYA SIGN TASSI
-16B30..16B36 ; Top   # Mn   [7] PAHAWH HMONG MARK CIM TUB..PAHAWH HMONG MARK CIM TAUM
-1E130..1E136 ; Top   # Mn   [7] NYIAKENG PUACHUE HMONG TONE-B..NYIAKENG PUACHUE HMONG TONE-D
-1E2EC..1E2EF ; Top   # Mn   [4] WANCHO TONE TUP..WANCHO TONE KOINI
+07EB..07F3    ; Top   # Mn   [9] NKO COMBINING SHORT HIGH TONE..NKO COMBINING DOUBLE DOT ABOVE
+07FD          ; Top   # Mn       NKO DANTAYALAN # Not really top, but assigned here to allow ccc to control mark order
+1885..1886    ; Top   # Mn   [2] MONGOLIAN LETTER ALI GALI BALUDA..MONGOLIAN LETTER ALI GALI THREE BALUDA
+10D24..10D27  ; Top   # Mn   [4] HANIFI ROHINGYA SIGN HARBAHAY..HANIFI ROHINGYA SIGN TASSI
+10EAB..10EAC  ; Top   # Mn   [2] YEZIDI COMBINING HAMZA MARK..YEZIDI COMBINING MADDA MARK
+10F82         ; Top   # Mn       OLD UYGHUR COMBINING DOT ABOVE
+10F84         ; Top   # Mn       OLD UYGHUR COMBINING TWO DOTS ABOVE
+16B30..16B36  ; Top   # Mn   [7] PAHAWH HMONG MARK CIM TUB..PAHAWH HMONG MARK CIM TAUM
+1E130..1E136  ; Top   # Mn   [7] NYIAKENG PUACHUE HMONG TONE-B..NYIAKENG PUACHUE HMONG TONE-D
+1E2AE         ; Top   # Mn       TOTO SIGN RISING TONE
+1E2EC..1E2EF  ; Top   # Mn   [4] WANCHO TONE TUP..WANCHO TONE KOINI
+1E944..1E94A  ; Top   # Mn   [7] ADLAM ALIF LENGTHENER..ADLAM NUKTA
 
 # ================================================
 
 # Indic_Positional_Category=Overstruck
-1BC9D..1BC9E ; Overstruck # Mn  [2] DUPLOYAN THICK LETTER SELECTOR..DUPLOYAN DOUBLE MARK
+1BC9D..1BC9E  ; Overstruck # Mn  [2] DUPLOYAN THICK LETTER SELECTOR..DUPLOYAN DOUBLE MARK
 
 # ================================================
 # ================================================
@@ -98,5 +104,6 @@ AA35         ; Top   # Mn       CHAM CONSONANT SIGN
 # ================================================
 
 # Indic_Positional_Category=NA
-180B..180D ; NA        # Mn  [3] MONGOLIAN FREE VARIATION SELECTOR ONE..MONGOLIAN FREE VARIATION SELECTOR THREE
-2D7F       ; NA        # Mn      TIFINAGH CONSONANT JOINER
+180B..180D   ; NA        # Mn  [3] MONGOLIAN FREE VARIATION SELECTOR ONE..MONGOLIAN FREE VARIATION SELECTOR THREE
+180F         ; NA        # Mn      MONGOLIAN FREE VARIATION SELECTOR FOUR
+2D7F         ; NA        # Mn      TIFINAGH CONSONANT JOINER

--- a/USE/IndicSyllabicCategory-Additional.txt
+++ b/USE/IndicSyllabicCategory-Additional.txt
@@ -1,9 +1,10 @@
 # Override values For Indic_Syllabic_Category
 # Not derivable
 # Initial version based on Unicode 7.0 by Andrew Glass 2014-03-17
-# Updated  for Unicode 10.0 by Andrew Glass 2017-07-25
-# Updated  for Unicode 12.1 by Andrew Glass 2019-05-24
-# Updated  for Unicode 13.0 by Andrew Glass 2020-07-28
+# Updated for Unicode 10.0 by Andrew Glass 2017-07-25
+# Updated for Unicode 12.1 by Andrew Glass 2019-05-24
+# Updated for Unicode 13.0 by Andrew Glass 2020-07-28
+# Updated for Unicode 14.0 by Andrew Glass 2021-09-25
 
 # ================================================
 # OVERRIDES TO ASSIGNED VALUES
@@ -17,28 +18,28 @@ AA29          ; Bindu  # Mn       CHAM VOWEL SIGN AA
 # ================================================
 
 # Indic_Syllabic_Category=Consonant
-0840..0858   ; Consonant # Lo  [25] MANDAIC LETTER HALQA..MANDAIC LETTER AIN
-0F00..0F01   ; Consonant # Lo   [2] TIBETAN SYLLABLE OM..TIBETAN MARK GTER YIG MGO TRUNCATED
-0F04..0F06   ; Consonant # Po       TIBETAN MARK INITIAL YIG MGO MDUN MA..TIBETAN MARK CARET YIG MGO PHUR SHAD MA
-19C1..19C7   ; Consonant # Lo   [7] NEW TAI LUE LETTER FINAL V..NEW TAI LUE LETTER FINAL B # Reassigned to avoid clustering with a base consonant
-25CC         ; Consonant # So       DOTTED CIRCLE
+0840..0858    ; Consonant # Lo  [25] MANDAIC LETTER HALQA..MANDAIC LETTER AIN
+0F00..0F01    ; Consonant # Lo   [2] TIBETAN SYLLABLE OM..TIBETAN MARK GTER YIG MGO TRUNCATED
+0F04..0F06    ; Consonant # Po       TIBETAN MARK INITIAL YIG MGO MDUN MA..TIBETAN MARK CARET YIG MGO PHUR SHAD MA
+19C1..19C7    ; Consonant # Lo   [7] NEW TAI LUE LETTER FINAL V..NEW TAI LUE LETTER FINAL B # Reassigned to avoid clustering with a base consonant
+25CC          ; Consonant # So       DOTTED CIRCLE
 
 # ================================================
 
 # Indic_Syllabic_Category=Consonant_Dead
-0F7F         ; Consonant_Dead    # Mc       TIBETAN SIGN RNAM BCAD # reassigned so that visarga will form an independent cluster
+0F7F          ; Consonant_Dead    # Mc       TIBETAN SIGN RNAM BCAD # reassigned so that visarga will form an independent cluster
 
 # ================================================
 
 # Indic_Syllabic_Category=Consonant_Final
-0F35         ; Consonant_Final   # Mn       TIBETAN MARK NGAS BZUNG NYI ZLA
-0F37         ; Consonant_Final   # Mn       TIBETAN MARK NGAS BZUNG SGOR RTAGS
-0FC6         ; Consonant_Final   # Mn       TIBETAN SYMBOL PADMA GDAN
+0F35          ; Consonant_Final   # Mn       TIBETAN MARK NGAS BZUNG NYI ZLA
+0F37          ; Consonant_Final   # Mn       TIBETAN MARK NGAS BZUNG SGOR RTAGS
+0FC6          ; Consonant_Final   # Mn       TIBETAN SYMBOL PADMA GDAN
 
 # ================================================
 
 # Indic_Syllabic_Category=Consonant_Final_Modifier
-1C36     ; Consonant_Final_Modifier  # Mn   LEPCHA SIGN RAN
+1C36          ; Consonant_Final_Modifier  # Mn   LEPCHA SIGN RAN
 
 # ================================================
 
@@ -54,9 +55,8 @@ AA29          ; Bindu  # Mn       CHAM VOWEL SIGN AA
 # ================================================
 
 # Indic_Syllabic_Category=Tone_Mark
-A982         ; Tone_Mark         # Mn       JAVANESE SIGN LAYAR# Not a repha, because it does not reorder to front of cluster
-1A7B..1A7C   ; Tone_Mark         # Mn   [2] TAI THAM SIGN MAI SAM..TAI THAM SIGN KHUEN-LUE KARAN
-1A7F         ; Tone_Mark         # Mn       TAI THAM COMBINING CRYPTOGRAMMIC DOT
+1A7B..1A7C    ; Tone_Mark         # Mn   [2] TAI THAM SIGN MAI SAM..TAI THAM SIGN KHUEN-LUE KARAN
+1A7F          ; Tone_Mark         # Mn       TAI THAM COMBINING CRYPTOGRAMMIC DOT
 
 # ================================================
 
@@ -72,41 +72,50 @@ AABD          ; Vowel_Independent # Lo       TAI VIET VOWEL AN
 # ================================================
 
 # Indic_Syllabic_Category=Consonant
-0800..0815   ; Consonant # Lo   [22] SAMARITAN LETTER ALAF..SAMARITAN LETTER TAAF
-1800         ; Consonant # Po        MONGOLIAN BIRGA # Reassigned so that legacy Birga + MFVS sequences still work
-1807         ; Consonant # Po        MONGOLIAN SIBE SYLLABLE BOUNDARY MARKER
-180A         ; Consonant # Po        MONGOLIAN NIRUGU
-1820..1878   ; Consonant # Lo   [88] MONGOLIAN LETTER A..MONGOLIAN LETTER CHA WITH TWO DOTS
-1843         ; Consonant # Lm        MONGOLIAN LETTER TODO LONG VOWEL SIGN
-2D30..2D67   ; Consonant # Lo   [56] TIFINAGH LETTER YA..TIFINAGH LETTER YO
-2D6F         ; Consonant # Lm        TIFINAGH MODIFIER LETTER LABIALIZATION MARK
-10AC0..10AC7 ; Consonant # Lo    [8] MANICHAEAN LETTER ALEPH..MANICHAEAN LETTER WAW
-10AC9..10AE4 ; Consonant # Lo   [28] MANICHAEAN LETTER ZAYIN..MANICHAEAN LETTER TAW
-10D00..10D23 ; Consonant # Lo   [36] HANIFI ROHINGYA LETTER A..HANIFI ROHINGYA MARK NA KHONNA
-10E80..10EA9 ; Consonant # Lo   [42] YEZIDI LETTER ELIF..YEZIDI LETTER ET
-10EB0..10EB1 ; Consonant # Lo    [2] YEZIDI LETTER LAM WITH DOT ABOVE..YEZIDI LETTER YOT WITH CIRCUMFLEX ABOVE
-10F30..10F45 ; Consonant # Lo   [22] SOGDIAN LETTER ALEPH..SOGDIAN INDEPENDENT SHIN
-111DA        ; Consonant # Lo        SHARADA EKAM
-#HIEROGLYPHS moved to new category
-#13000..1342E ; Consonant # Lo [1071] EGYPTIAN HIEROGLYPH A001..EGYPTIAN HIEROGLYPH AA032
+0800..0815    ; Consonant # Lo   [22] SAMARITAN LETTER ALAF..SAMARITAN LETTER TAAF
+1800          ; Consonant # Po        MONGOLIAN BIRGA # Reassigned so that legacy Birga + MFVS sequences still work
+1807          ; Consonant # Po        MONGOLIAN SIBE SYLLABLE BOUNDARY MARKER
+180A          ; Consonant # Po        MONGOLIAN NIRUGU
+1820..1878    ; Consonant # Lo   [88] MONGOLIAN LETTER A..MONGOLIAN LETTER CHA WITH TWO DOTS
+1843          ; Consonant # Lm        MONGOLIAN LETTER TODO LONG VOWEL SIGN
+2D30..2D67    ; Consonant # Lo   [56] TIFINAGH LETTER YA..TIFINAGH LETTER YO
+2D6F          ; Consonant # Lm        TIFINAGH MODIFIER LETTER LABIALIZATION MARK
+10570..1057A  ; Consonant # Lo   [11] VITHKUQI CAPITAL LETTER A..VITHKUQI CAPITAL LETTER GA
+1057C..1058A  ; Consonant # Lo   [15] VITHKUQI CAPITAL LETTER HA..VITHKUQI CAPITAL LETTER RE
+1058C..10592  ; Consonant # Lo    [7] VITHKUQI CAPITAL LETTER SE..VITHKUQI CAPITAL LETTER XE
+10594..10595  ; Consonant # Lo    [2] VITHKUQI CAPITAL LETTER Y..VITHKUQI CAPITAL LETTER ZE
+10597..105A1  ; Consonant # Lo   [11] VITHKUQI SMALL LETTER A..VITHKUQI SMALL LETTER GA
+105A3..105B1  ; Consonant # Lo   [15] VITHKUQI SMALL LETTER HA..VITHKUQI SMALL LETTER RE
+105B3..105B9  ; Consonant # Lo    [7] VITHKUQI SMALL LETTER SE..VITHKUQI SMALL LETTER XE
+105BB..105BC  ; Consonant # Lo    [2] VITHKUQI SMALL LETTER Y..VITHKUQI SMALL LETTER ZE
+10AC0..10AC7  ; Consonant # Lo    [8] MANICHAEAN LETTER ALEPH..MANICHAEAN LETTER WAW
+10AC9..10AE4  ; Consonant # Lo   [28] MANICHAEAN LETTER ZAYIN..MANICHAEAN LETTER TAW
+10D00..10D23  ; Consonant # Lo   [36] HANIFI ROHINGYA LETTER A..HANIFI ROHINGYA MARK NA KHONNA
+10E80..10EA9  ; Consonant # Lo   [42] YEZIDI LETTER ELIF..YEZIDI LETTER ET
+10EB0..10EB1  ; Consonant # Lo    [2] YEZIDI LETTER LAM WITH DOT ABOVE..YEZIDI LETTER YOT WITH CIRCUMFLEX ABOVE
+10F30..10F45  ; Consonant # Lo   [22] SOGDIAN LETTER ALEPH..SOGDIAN INDEPENDENT SHIN
+111DA         ; Consonant # Lo        SHARADA EKAM
+#HIEROGLYPHS to be moved to new category
+13000..1342E  ; Consonant # Lo [1071] EGYPTIAN HIEROGLYPH A001..EGYPTIAN HIEROGLYPH AA032
 #For the Begin and End segment to be handled fully correctly, the cluster model needs to be modified.
-#13437..13438 ; Consonant # Lo    [2] EGYPTIAN HIEROGLYPH BEGIN SEGMENT..EGYPTIAN HIEROGLYPH END SEGMENT
-16B00..16B2F ; Consonant # Lo   [48] PAHAWH HMONG VOWEL KEEB..PAHAWH HMONG CONSONANT CAU
-16F00..16F4A ; Consonant # Lo   [75] MIAO LETTER PA..MIAO LETTER RTE
-16FE4        ; Consonant # Mn        KHITAN SMALL SCRIPT FILLER
-18B00..18CD5 ; Consonant # Lo  [470] KHITAN SMALL SCRIPT CHARACTER-18B00..KHITAN SMALL SCRIPT CHARACTER-18CD5
-1BC00..1BC6A ; Consonant # Lo  [107] DUPLOYAN LETTER H..DUPLOYAN LETTER VOCALIC M
-1BC70..1BC7C ; Consonant # Lo   [13] DUPLOYAN AFFIX LEFT HORIZONTAL SECANT..DUPLOYAN AFFIX ATTACHED TANGENT HOOK 
-1BC80..1BC88 ; Consonant # Lo    [9] DUPLOYAN AFFIX HIGH ACUTE..DUPLOYAN AFFIX HIGH VERTICAL
-1BC90..1BC99 ; Consonant # Lo   [10] DUPLOYAN AFFIX LOW ACUTE..DUPLOYAN AFFIX LOW ARROW
-1E100..1E12C ; Consonant # Lo   [45] NYIAKENG PUACHUE HMONG LETTER MA..NYIAKENG PUACHUE HMONG LETTER W
-1E137..1E13D ; Consonant # Lm    [7] NYIAKENG PUACHUE HMONG SIGN FOR PERSON..NYIAKENG PUACHUE HMONG SYLLABLE LENGTHENER
-1E14E        ; Consonant # Lo        NYIAKENG PUACHUE HMONG LOGOGRAM NYAJ
-1E14F        ; Consonant # So        NYIAKENG PUACHUE HMONG CIRCLED CA
-1E2C0..1E2EB ; Consonant # Lo   [44] WANCHO LETTER AA..WANCHO LETTER YIH
-1E900..1E921 ; Consonant # Lu   [34] ADLAM CAPITAL LETTER ALIF..ADLAM CAPITAL LETTER SHA
-1E922..1E943 ; Consonant # Ll   [34] ADLAM SMALL LETTER ALIF..ADLAM SMALL LETTER SHA
-1E94B        ; Consonant # Lm        ADLAM NASALIZATION MARK
+13437..13438  ; Consonant # Lo    [2] EGYPTIAN HIEROGLYPH BEGIN SEGMENT..EGYPTIAN HIEROGLYPH END SEGMENT
+16B00..16B2F  ; Consonant # Lo   [48] PAHAWH HMONG VOWEL KEEB..PAHAWH HMONG CONSONANT CAU
+16F00..16F4A  ; Consonant # Lo   [75] MIAO LETTER PA..MIAO LETTER RTE
+16FE4         ; Consonant # Mn        KHITAN SMALL SCRIPT FILLER          # Avoids Mn pushing this into VOWEL class
+18B00..18CD5  ; Consonant # Lo  [470] KHITAN SMALL SCRIPT CHARACTER-18B00..KHITAN SMALL SCRIPT CHARACTER-18CD5
+1BC00..1BC6A  ; Consonant # Lo  [107] DUPLOYAN LETTER H..DUPLOYAN LETTER VOCALIC M
+1BC70..1BC7C  ; Consonant # Lo   [13] DUPLOYAN AFFIX LEFT HORIZONTAL SECANT..DUPLOYAN AFFIX ATTACHED TANGENT HOOK 
+1BC80..1BC88  ; Consonant # Lo    [9] DUPLOYAN AFFIX HIGH ACUTE..DUPLOYAN AFFIX HIGH VERTICAL
+1BC90..1BC99  ; Consonant # Lo   [10] DUPLOYAN AFFIX LOW ACUTE..DUPLOYAN AFFIX LOW ARROW
+1E100..1E12C  ; Consonant # Lo   [45] NYIAKENG PUACHUE HMONG LETTER MA..NYIAKENG PUACHUE HMONG LETTER W
+1E137..1E13D  ; Consonant # Lm    [7] NYIAKENG PUACHUE HMONG SIGN FOR PERSON..NYIAKENG PUACHUE HMONG SYLLABLE LENGTHENER
+1E14E         ; Consonant # Lo        NYIAKENG PUACHUE HMONG LOGOGRAM NYAJ
+1E14F         ; Consonant # So        NYIAKENG PUACHUE HMONG CIRCLED CA
+1E290..1E2AD  ; Consonant # Lo   [30] TOTO LETTER PA..TOTO LETTER A
+1E2C0..1E2EB  ; Consonant # Lo   [44] WANCHO LETTER AA..WANCHO LETTER YIH
+1E900..1E921  ; Consonant # Lu   [34] ADLAM CAPITAL LETTER ALIF..ADLAM CAPITAL LETTER SHA
+1E922..1E943  ; Consonant # Ll   [34] ADLAM SMALL LETTER ALIF..ADLAM SMALL LETTER SHA
+1E94B         ; Consonant # Lm        ADLAM NASALIZATION MARK
 
 # ================================================
 
@@ -116,13 +125,13 @@ AABD          ; Vowel_Independent # Lo       TAI VIET VOWEL AN
 # ================================================
 
 # Indic_Syllabic_Category=Gemination_Mark
-10D27      ; Gemination_Mark # Mn       HANIFI ROHINGYA SIGN TASSI
+10D27         ; Gemination_Mark   # Mn       HANIFI ROHINGYA SIGN TASSI
 
 # ================================================
 
 # Indic_Syllabic_Category=Modifying_Letter
-FE00..FE0F   ; Modifying_Letter  # Mn  [16] VARIATION SELECTOR-1..VARIATION SELECTOR-16# Need to treat them as isolated bases so they don't merge with a cluster in invalid scenarios
-16F50        ; Modifying_Letter  # Lo       MIAO LETTER NASALIZATION
+FE00..FE0F    ; Modifying_Letter  # Mn  [16] VARIATION SELECTOR-1..VARIATION SELECTOR-16# Need to treat them as isolated bases so they don't merge with a cluster in invalid scenarios
+16F50         ; Modifying_Letter  # Lo       MIAO LETTER NASALIZATION
 
 # ================================================
 
@@ -136,49 +145,52 @@ FE00..FE0F   ; Modifying_Letter  # Mn  [16] VARIATION SELECTOR-1..VARIATION SELE
 16F4F         ; Nukta            # Mn       MIAO SIGN CONSONANT MODIFIER BAR
 1BC9D..1BC9E  ; Nukta            # Mn   [2] DUPLOYAN THICK LETTER SELECTOR..DUPLOYAN DOUBLE MARK
 1E944..1E94A  ; Nukta            # Mn   [7] ADLAM ALIF LENGTHENER..ADLAM NUKTA
+10F82..10F85  ; Nukta            # Mn   [4] OLD UYGHUR COMBINING DOT ABOVE..OLD UYGHUR COMBINING TWO DOTS BELOW
 
 # ================================================
 
 # Indic_Syllabic_Category=Number
-10D30..10D39 ; Number              # Nd  [10] HANIFI ROHINGYA DIGIT ZERO..HANIFI ROHINGYA DIGIT NINE
-10F51..10F54 ; Number              # No   [4] SOGDIAN NUMBER ONE..SOGDIAN NUMBER ONE HUNDRED
-1E140..1E149 ; Number              # Nd  [10] NYIAKENG PUACHUE HMONG DIGIT ZERO..NYIAKENG PUACHUE HMONG DIGIT NINE
-1E2F0..1E2F9 ; Number              # Nd  [10] WANCHO DIGIT ZERO..WANCHO DIGIT NINE
-1E950..1E959 ; Number              # Nd  [10] ADLAM DIGIT ZERO..ADLAM DIGIT NINE
+10D30..10D39  ; Number              # Nd  [10] HANIFI ROHINGYA DIGIT ZERO..HANIFI ROHINGYA DIGIT NINE
+10F51..10F54  ; Number              # No   [4] SOGDIAN NUMBER ONE..SOGDIAN NUMBER ONE HUNDRED
+16AC0..16AC9  ; Number              # Nd  [10] TANGSA DIGIT ZERO..TANGSA DIGIT NINE
+1E140..1E149  ; Number              # Nd  [10] NYIAKENG PUACHUE HMONG DIGIT ZERO..NYIAKENG PUACHUE HMONG DIGIT NINE
+1E2F0..1E2F9  ; Number              # Nd  [10] WANCHO DIGIT ZERO..WANCHO DIGIT NINE
+1E950..1E959  ; Number              # Nd  [10] ADLAM DIGIT ZERO..ADLAM DIGIT NINE
 
 # ================================================
 
 # Indic_Syllabic_Category=Tone_Mark
-07EB..07F3   ; Tone_Mark           # Mn   [9] NKO COMBINING SHORT HIGH TONE..NKO COMBINING DOUBLE DOT ABOVE
-07FD         ; Tone_Mark           # Mn       NKO DANTAYALAN
-0F86..0F87   ; Tone_Mark           # Mn   [2] TIBETAN SIGN LCI RTAGS..TIBETAN SIGN YANG RTAGS
-17CF         ; Tone_Mark           # Mn       KHMER SIGN AHSDA
-10D24..10D26 ; Tone_Mark           # Mn   [3] HANIFI ROHINGYA SIGN HARBAHAY..HANIFI ROHINGYA SIGN TANA
-10F46..10F50 ; Tone_Mark           # Mn  [11] SOGDIAN COMBINING DOT BELOW..SOGDIAN COMBINING STROKE BELOW
-16B30..16B36 ; Tone_Mark           # Mn   [7] PAHAWH HMONG MARK CIM TUB..PAHAWH HMONG MARK CIM TAUM
-16F8F..16F92 ; Tone_Mark           # Mn   [4] MIAO TONE RIGHT..MIAO TONE BELOW
-1E130..1E136 ; Tone_Mark           # Mn   [7] NYIAKENG PUACHUE HMONG TONE-B..NYIAKENG PUACHUE HMONG TONE-D
-1E2EC..1E2EF ; Tone_Mark           # Mn   [4] WANCHO TONE TUP..WANCHO TONE KOINI
+07EB..07F3    ; Tone_Mark           # Mn   [9] NKO COMBINING SHORT HIGH TONE..NKO COMBINING DOUBLE DOT ABOVE
+07FD          ; Tone_Mark           # Mn       NKO DANTAYALAN
+0F86..0F87    ; Tone_Mark           # Mn   [2] TIBETAN SIGN LCI RTAGS..TIBETAN SIGN YANG RTAGS
+17CF          ; Tone_Mark           # Mn       KHMER SIGN AHSDA
+10D24..10D26  ; Tone_Mark           # Mn   [3] HANIFI ROHINGYA SIGN HARBAHAY..HANIFI ROHINGYA SIGN TANA
+10F46..10F50  ; Tone_Mark           # Mn  [11] SOGDIAN COMBINING DOT BELOW..SOGDIAN COMBINING STROKE BELOW
+16B30..16B36  ; Tone_Mark           # Mn   [7] PAHAWH HMONG MARK CIM TUB..PAHAWH HMONG MARK CIM TAUM
+16F8F..16F92  ; Tone_Mark           # Mn   [4] MIAO TONE RIGHT..MIAO TONE BELOW
+1E130..1E136  ; Tone_Mark           # Mn   [7] NYIAKENG PUACHUE HMONG TONE-B..NYIAKENG PUACHUE HMONG TONE-D
+1E2AE         ; Tone_Mark           # Mn       TOTO SIGN RISING TONE
+1E2EC..1E2EF  ; Tone_Mark           # Mn   [4] WANCHO TONE TUP..WANCHO TONE KOINI
 
 # ================================================
 
 # Indic_Syllabic_Category=Virama
-2D7F         ; Virama              # Mn       TIFINAGH CONSONANT JOINER
-13430..13436 ; Virama              # Cf   [7] EGYPTIAN HIEROGLYPH VERTICAL JOINER..EGYPTIAN HIEROGLYPH OVERLAY MIDDLE
+2D7F          ; Virama              # Mn       TIFINAGH CONSONANT JOINER
+13430..13436  ; Virama              # Cf   [7] EGYPTIAN HIEROGLYPH VERTICAL JOINER..EGYPTIAN HIEROGLYPH OVERLAY MIDDLE
 
 # ================================================
 
 # Indic_Syllabic_Category=Vowel_Independent
-AAB1         ; Vowel_Independent   # Lo       TAI VIET VOWEL AA
-AABA         ; Vowel_Independent   # Lo       TAI VIET VOWEL UA
-AABD         ; Vowel_Independent   # Lo       TAI VIET VOWEL AN
+AAB1          ; Vowel_Independent   # Lo       TAI VIET VOWEL AA
+AABA          ; Vowel_Independent   # Lo       TAI VIET VOWEL UA
+AABD          ; Vowel_Independent   # Lo       TAI VIET VOWEL AN
 
 # ================================================
 
 # Indic_Syllabic_Category=Vowel_Dependent
-0B55          ; Vowel_Dependent   # Mn       ORIYA SIGN OVERLINE
-10EAB..10EAC  ; Vowel_Dependent   # Mn   [2] YEZIDI COMBINING HAMZA MARK..YEZIDI COMBINING MADDA MARK
-16F51..16F87  ; Vowel_Dependent   # Mc  [55] MIAO SIGN ASPIRATION..MIAO VOWEL SIGN UI
+0B55          ; Vowel_Dependent     # Mn       ORIYA SIGN OVERLINE
+10EAB..10EAC  ; Vowel_Dependent     # Mn   [2] YEZIDI COMBINING HAMZA MARK..YEZIDI COMBINING MADDA MARK
+16F51..16F87  ; Vowel_Dependent     # Mc  [55] MIAO SIGN ASPIRATION..MIAO VOWEL SIGN UI
 
 # ================================================
 # ================================================


### PR DESCRIPTION
New IPC values provided for Old Uyghur, Toto, and Mongolian
ISC override removed for A982 JAVANESE SIGN LAYAR to align with updated ISC
New ISC values provided for Vithkuqi, Toto, Old Uyghur, Tangsa
Formatting alignment changes.

Closes #15