### PR TITLE
Fix various typos

### DIFF
--- a/EgyptianOpenType/eotHelper.py
+++ b/EgyptianOpenType/eotHelper.py
@@ -43,7 +43,7 @@ ver = 400
 
 class EotHelper:
     def __init__(self, pvar):
-        """Intialize the Egyptian OpenType helper class with config variable."""
+        """Initialize the Egyptian OpenType helper class with config variable."""
         # print(sys.version)
 
         self.pvar = pvar
@@ -79,7 +79,7 @@ class EotHelper:
         print(pvar['fontsrc'])
     
     def initializeVTP(self):
-        """Intialize the Volt OpenType project for the currently instantiated class."""
+        """Initialize the Volt OpenType project for the currently instantiated class."""
         def setdefaultfeatures():
             defaultObj = {}
             defaultObj['haln'] = []
@@ -595,7 +595,7 @@ class EotHelper:
 
     #Structure
     def pres(self):
-        # def loadr090subpairs(): # for controll based rotations
+        # def loadr090subpairs(): # for control based rotations
         #     subpairs = []
         #     for rotatedglyph in self.rotated090:
         #         baseglyph = rotatedglyph[0:-1] 
@@ -603,7 +603,7 @@ class EotHelper:
         #             subpair = {'sub':[baseglyph,'r90'],'target':[rotatedglyph] }
         #             subpairs.append(subpair)
         #     return subpairs
-        # def loadr180subpairs(): # for controll based rotations
+        # def loadr180subpairs(): # for control based rotations
         #     subpairs = []
         #     for rotatedglyph in self.rotated180:
         #         baseglyph = rotatedglyph[0:-1] 
@@ -611,7 +611,7 @@ class EotHelper:
         #             subpair = {'sub':[baseglyph,'r180'],'target':[rotatedglyph] }
         #             subpairs.append(subpair)
         #     return subpairs
-        # def loadr270subpairs(): # for controll based rotations
+        # def loadr270subpairs(): # for control based rotations
         #     subpairs = []
         #     for rotatedglyph in self.rotated270:
         #         baseglyph = rotatedglyph[0:-1] 
@@ -1589,7 +1589,7 @@ class EotHelper:
             elif dec > 0 and dec <= 65535: #mapped BMP characters
                 if name in punctuation:
                     group = 'Punctuation'
-                elif (variation): #name matches the patter for a variation selector
+                elif (variation): #name matches the pattern for a variation selector
                     group = 'VS'
                 elif dec == 9676: #dotted circle as generic base
                     group = 'Chr'
@@ -3107,7 +3107,7 @@ class EotHelper:
         #all levels
         #calculatemax 16-20
         def targetmax(level): #20-23
-            # For level 0, let the calcualted row max through
+            # For level 0, let the calculated row max through
             # rm{1-6} (|sh{6}) -> no changes
             # For levels 1 and 2, force the target max size
             # 1: rm{1-6} sh{(2-5)} -> rm$1 sh$1             
@@ -3281,7 +3281,7 @@ class EotHelper:
                     # j = colspersum[level][i] # the number of possible columns
                     j = self.pvar['targetwidthmax'][level] # the number of possible columns
                     while j >= 1: # iterate down for each possible column depth 
-                        subs = ['dv'+str(i)] # intial sub is the current delta value
+                        subs = ['dv'+str(i)] # initial sub is the current delta value
                         k = j # append dd1 value for each column
                         while k >= 1:
                             subs.append('dd1')
@@ -4298,7 +4298,7 @@ class EotHelper:
                 while i >= 1:
                     j = self.pvar['targetheightmax'][level] # the number of possible columns
                     while j >= 1: # iterate down for each possible row depth 
-                        subs = ['dv'+str(i)] # intial sub is the current delta value
+                        subs = ['dv'+str(i)] # initial sub is the current delta value
                         k = j # append dd1 value for each column
                         while k >= 1:
                             subs.append('dd1')
@@ -5078,7 +5078,7 @@ class EotHelper:
             return lookupObjs
         def mapTargetSize():
             #sh{1-8} sv{1-6} -> t$1$2
-            #exclude stems12 since o shapes are resued for insertion plates
+            #exclude stems12 since o shapes are reused for insertion plates
             lookupObj = {'feature':'psts','name':'','marks':'','contexts':[],'details':[]}
             lookupObj['name'] = 'maptargetsize'
             lookupObj['exceptcontexts'] = [{'left':[],'right':['stems_12']}]
@@ -5634,7 +5634,7 @@ class EotHelper:
 
         return lines
 
-# COMPLILE TTX
+# COMPILE TTX
     def compileTTX(self):
         def dumpTTX(fontout):
             ttxfont = ttx.TTFont('out/'+fontout)

--- a/EgyptianOpenType/pres.py
+++ b/EgyptianOpenType/pres.py
@@ -3,7 +3,7 @@
 
 pres = [
     # Lookup - tcm start
-    # TODO: Move these substitutions to the Default langauge
+    # TODO: Move these substitutions to the Default language
     # {'name' : 'tcm_open', 'marks' : '',
     # 'contexts' : [{'left':[],'right':['characters_latn']}],
     # 'details' : [
@@ -338,7 +338,7 @@ pres = [
     'details' : [
         {'sub':['su'],'target':['su','r2bA']},
     ]},
-    # Lookup - level 2 row begin afer corner before 2 end
+    # Lookup - level 2 row begin after corner before 2 end
     {'name' : 'r2b_corner', 'marks' : '*parensub',
     'contexts' : [{'left':[],'right':['r2eA']}],
     'details' : [{'sub':['corners0a'],'target':['corners0a','r1bA','r2bA']},]},
@@ -350,7 +350,7 @@ pres = [
     {'name' : 'r1_om1', 'marks' : 'parens',
     'contexts' : [{'left':['r1bA'],'right':['r1bA']}],
     'details' : [{'sub':['corners0a'],'target':['r1eA','corners0a']},]},
-    # Lookup - level 1 row begin afer corner before 1 end
+    # Lookup - level 1 row begin after corner before 1 end
     {'name' : 'corner_swapandsize', 'marks' : '',
     'exceptcontexts' : [{'left':['Qf'],'right':[]}],
     'details' : [

--- a/USE/IndicPositionalCategory-Additional.txt
+++ b/USE/IndicPositionalCategory-Additional.txt
@@ -2,7 +2,7 @@
 # Not derivable
 # Initial version based on Unicode 7.0 by Andrew Glass 2014-03-17
 # Updated  for Unicode 10.0 by Andrew Glass 2017-07-25
-# Ammended for Unicode 10.0 by Andrew Glass 2018-09-21
+# Amended for Unicode 10.0 by Andrew Glass 2018-09-21
 # Updated  for L2/19-083    by Andrew Glass 2019-05-06
 # Updated  for Unicode 12.1 by Andrew Glass 2019-05-30
 # Updated  for Unicode 13.0 by Andrew Glass 2020-07-28
@@ -60,9 +60,9 @@ AA35         ; Top   # Mn       CHAM CONSONANT SIGN
 10AE5        ; Bottom # Mn       MANICHAEAN ABBREVIATION MARK ABOVE # Not really bottom, but here for ccc to control
 10AE6        ; Bottom # Mn       MANICHAEAN ABBREVIATION MARK BELOW
 10F46..10F47 ; Bottom # Mn   [2] SOGDIAN COMBINING DOT BELOW..SOGDIAN COMBINING TWO DOTS BELOW
-10F48..10F4A ; Bottom # Mn   [3] SOGDIAN COMBINING DOT ABOVE..SOGDIAN COMBINING CURVE ABOVE # Overriden to below because ccc-based Normalization controls order
+10F48..10F4A ; Bottom # Mn   [3] SOGDIAN COMBINING DOT ABOVE..SOGDIAN COMBINING CURVE ABOVE # Overridden to below because ccc-based Normalization controls order
 10F4B        ; Bottom # Mn       SOGDIAN COMBINING CURVE BELOW
-10F4C        ; Bottom # Mn       SOGDIAN COMBINING HOOK ABOVE # Overriden to below because ccc-based Normalization controls order
+10F4C        ; Bottom # Mn       SOGDIAN COMBINING HOOK ABOVE # Overridden to below because ccc-based Normalization controls order
 10F4D..10F50 ; Bottom # Mn   [4] SOGDIAN COMBINING HOOK BELOW..SOGDIAN COMBINING STROKE BELOW
 16F4F        ; Bottom # Mn       MIAO SIGN CONSONANT MODIFIER BAR
 16F51..16F87 ; Bottom # Mc  [55] MIAO SIGN ASPIRATION..MIAO VOWEL SIGN UI


### PR DESCRIPTION
Found via `codespell -q 3 -L ba,haa,nd,pres,te,ue,yot`  
Discovered through downstream harfbuzz project https://github.com/harfbuzz/harfbuzz/pull/3464#pullrequestreview-901026733